### PR TITLE
Add xclip

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -98,6 +98,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     vim \
     websockify \
     wget \
+    xclip \
     xtermcontrol \
     xz-utils \
 	&& ln -s /usr/bin/fdfind /usr/local/bin/fd \


### PR DESCRIPTION
Fix emacs message

```
Doom loaded 259 packages across 59 modules in 2.077s
(file-error Searching for program xclip no such file)                                        
Updating buffer list...
Formats have changed, recompiling...done
```